### PR TITLE
validate不足部分の設定

### DIFF
--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -1,5 +1,7 @@
 class TrainingSuggestion < ApplicationRecord
   belongs_to :user
+
+  validates :running_distance, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, presence: true
   enum intensity: { E: 0, M: 1, T: 2, I: 3, R: 4 }
 
   # 練習強度(intensity)ごとにランニング時のVO2maxに対する負荷の比率を定義


### PR DESCRIPTION
## 概要

各モデルのvalidateが足りていない部分の追加

## コメント

training_suggestionテーブルのrunning_distanceカラムのvalidate追加
走行距離に入力できる値に制限(0~100)をかけた